### PR TITLE
feat: wire routing policy across runtime surfaces

### DIFF
--- a/.cortex/policy/routing/routing-policy.yaml
+++ b/.cortex/policy/routing/routing-policy.yaml
@@ -1,0 +1,136 @@
+version: 0.4
+metadata:
+  owner: orchestration
+  description: Unified routing policy for Cortex-OS entry points.
+  last_review: '2025-10-03'
+interfaces:
+  webui:
+    app: apps/cortex-webui
+    priority_base: 60
+    safety:
+      allow_network: ask
+      allow_fs_write: tempdir
+  cli:
+    app: apps/cortex-os
+    priority_base: 80
+    safety:
+      allow_network: true
+      allow_fs_write: workspace_only
+  mcp:
+    pkg: packages/mcp
+    priority_base: 70
+    safety:
+      allow_network: false
+      allow_fs_write: tempdir
+  a2a:
+    pkg: packages/a2a
+    priority_base: 90
+    safety:
+      allow_network: true
+      allow_fs_write: workspace_only
+priority_rules:
+  - id: pr-runbook-sev1
+    if:
+      tags_any:
+        - runbook
+        - sev1
+        - incident
+    then:
+      boost: 40
+      prefer_capabilities:
+        - runbook_execute
+      require_approval: false
+  - id: pr-cli-dev-ops
+    if:
+      interface: cli
+      command_prefix_any:
+        - cortex-os
+        - just
+        - pnpm
+    then:
+      boost: 25
+      prefer_capabilities:
+        - code_edit
+        - test_execute
+  - id: pr-ci-safe
+    if:
+      interface: a2a
+      source: ci
+    then:
+      boost: 20
+      safety_override:
+        sandbox: process:node
+        allow_fs_write: workspace_only
+      prefer_capabilities:
+        - test_execute
+routing:
+  strategy:
+    plan_with: packages/orchestration/planners/policy-driven
+    select_by:
+      - capability_score
+      - availability
+      - cost
+    fallbacks:
+      - packages/agents/generalist
+    guardrails: packages/security/policies/llm-guardrails.yaml
+    evidence:
+      require_provenance: true
+      sink: packages/memories
+capability_matrix:
+  required:
+    - id: code_edit
+      providers:
+        - packages/agents/dev
+        - packages/agents/generalist
+    - id: data_retrieval
+      providers:
+        - packages/agents/researcher
+        - packages/agents/generalist
+    - id: test_execute
+      providers:
+        - packages/agents/test-runner
+    - id: runbook_execute
+      providers:
+        - packages/agents/ops-runbook
+  incompatible:
+    - id: network_forbidden
+      disallow_providers:
+        - packages/agents/web-fetcher
+approvals:
+  policies:
+    - id: never-for-readonly
+      if:
+        operation: read_only
+      then:
+        require_approval: false
+    - id: high-risk-file-write
+      if:
+        operation: fs_write
+        path_not_in:
+          - ./workspace
+          - ./tmp
+      then:
+        require_approval: true
+        approvers:
+          - owner
+          - security
+    - id: prod-impact
+      if:
+        env: production
+        operation_any:
+          - deploy
+          - migrate
+          - delete
+      then:
+        require_approval: true
+        approvers:
+          - owner
+          - ops
+telemetry:
+  otel_spans: true
+  a2a_events_topic: routing.decisions
+  redact:
+    fields:
+      - api_key
+      - bearer_token
+      - oauth.refresh_token

--- a/apps/cortex-os/src/http/runtime-server.ts
+++ b/apps/cortex-os/src/http/runtime-server.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { URL } from 'node:url';
+import type { OrchestrationFacade, RoutingDecision, RoutingRequest } from '@cortex-os/orchestration';
 import type { ArtifactRepository } from '../persistence/artifact-repository.js';
 import { OptimisticLockError } from '../persistence/errors.js';
 import type { EvidenceRepository, SaveEvidenceInput } from '../persistence/evidence-repository.js';
@@ -16,10 +17,11 @@ export interface RuntimeHttpServer {
 }
 
 export interface RuntimeHttpDependencies {
-	tasks: TaskRepository;
-	profiles: ProfileRepository;
-	artifacts: ArtifactRepository;
-	evidence: EvidenceRepository;
+\ttasks: TaskRepository;
+\tprofiles: ProfileRepository;
+\tartifacts: ArtifactRepository;
+\tevidence: EvidenceRepository;
+\torchestration: OrchestrationFacade;
 }
 
 class HttpError extends Error {
@@ -178,6 +180,9 @@ async function handleApiRequest(
 			return;
 		case 'artifacts':
 			await handleArtifactsRoute(req, res, url, segments, dependencies.artifacts);
+			return;
+		case 'routing':
+			await handleRoutingRoute(req, res, url, segments, dependencies.orchestration);
 			return;
 		case 'evidence':
 			await handleEvidenceRoute(req, res, url, segments, dependencies.evidence);
@@ -345,11 +350,11 @@ async function handleProfilesRoute(
 }
 
 async function handleArtifactsRoute(
-	req: IncomingMessage,
-	res: ServerResponse,
-	url: URL,
-	segments: string[],
-	artifacts: ArtifactRepository,
+		req: IncomingMessage,
+		res: ServerResponse,
+		url: URL,
+		segments: string[],
+		artifacts: ArtifactRepository,
 ): Promise<void> {
 	if (segments.length === 2) {
 		if (req.method === 'GET') {
@@ -450,6 +455,131 @@ async function handleArtifactsRoute(
 	}
 
 	sendNotFound(res, 'Unsupported artifact route');
+}
+
+type OrchestrationRouter = OrchestrationFacade['router'];
+
+async function handleRoutingRoute(
+		req: IncomingMessage,
+		res: ServerResponse,
+		_url: URL,
+		segments: string[],
+		orchestration: OrchestrationFacade,
+): Promise<void> {
+	const router = orchestration?.router;
+	if (!router) {
+		throw new HttpError(503, 'Routing service unavailable', 'ROUTING_UNAVAILABLE');
+	}
+	if (segments.length === 3 && segments[2] === 'dry-run') {
+		await handleRoutingDryRun(req, res, router);
+		return;
+	}
+	if (segments.length === 4 && segments[2] === 'explain') {
+		await handleRoutingExplain(req, res, segments[3], router);
+		return;
+	}
+	sendNotFound(res, 'Unsupported routing route');
+}
+
+async function handleRoutingDryRun(
+		req: IncomingMessage,
+		res: ServerResponse,
+		router: OrchestrationRouter,
+): Promise<void> {
+	if (req.method !== 'POST') {
+		throw new HttpError(405, 'Method not allowed', 'METHOD_NOT_ALLOWED');
+	}
+	const body = await readJsonBody(req);
+	const request = buildRoutingRequest(body);
+	try {
+		const decision = await router.route(request);
+		sendJson(res, 200, { decision });
+	} catch (error) {
+		const mapped = mapRoutingError(error);
+		if (mapped) throw mapped;
+		throw error;
+	}
+}
+
+async function handleRoutingExplain(
+		req: IncomingMessage,
+		res: ServerResponse,
+		requestId: string,
+		router: OrchestrationRouter,
+): Promise<void> {
+	if (req.method !== 'GET') {
+		throw new HttpError(405, 'Method not allowed', 'METHOD_NOT_ALLOWED');
+	}
+	const decision: RoutingDecision | undefined = router.explain(requestId);
+	if (!decision) {
+		sendNotFound(res, 'Routing decision not found', { requestId });
+		return;
+	}
+	sendJson(res, 200, { decision });
+}
+
+function buildRoutingRequest(payload: unknown): RoutingRequest {
+	const candidate =
+		payload && typeof payload === 'object' && !Array.isArray(payload)
+			? (payload as Record<string, unknown>)
+			: {};
+	const metadata = parseRoutingMetadata(candidate.metadata);
+	return {
+		requestId: getStringField(candidate.requestId),
+		interfaceId:
+			getStringField(candidate.interfaceId) ?? getStringField(candidate.interface) ?? 'cli',
+		capabilities: toStringArray(candidate.capabilities),
+		tags: toStringArray(candidate.tags),
+		source: getStringField(candidate.source) ?? 'runtime-http',
+		command: getStringField(candidate.command),
+		env: getStringField(candidate.env),
+		operation: getStringField(candidate.operation),
+		metadata,
+	};
+}
+
+function getStringField(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toStringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const unique = new Set<string>();
+	for (const entry of value) {
+		if (typeof entry === 'string') {
+			const trimmed = entry.trim();
+			if (trimmed.length > 0) unique.add(trimmed);
+		}
+	}
+	return Array.from(unique);
+}
+
+function parseRoutingMetadata(value: unknown): Record<string, unknown> | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (Array.isArray(value) || typeof value !== 'object') {
+		throw new HttpError(400, 'metadata must be an object', 'ROUTING_METADATA_INVALID');
+	}
+	return { ...(value as Record<string, unknown>) };
+}
+
+function mapRoutingError(error: unknown): HttpError | undefined {
+	if (!(error instanceof Error)) return undefined;
+	const message = error.message ?? '';
+	if (message === 'routing_policy:not_loaded') {
+		return new HttpError(503, 'Routing policy not loaded', 'ROUTING_POLICY_NOT_LOADED');
+	}
+	if (message.startsWith('routing_policy:interface_missing:')) {
+		const parts = message.split(':');
+		const interfaceId = parts[parts.length - 1] ?? 'unknown';
+		return new HttpError(
+			404,
+			`Routing interface '${interfaceId}' not found`,
+			'ROUTING_INTERFACE_NOT_FOUND',
+		);
+	}
+	return undefined;
 }
 
 async function handleEvidenceRoute(

--- a/apps/cortex-os/src/http/runtime-server.ts
+++ b/apps/cortex-os/src/http/runtime-server.ts
@@ -566,7 +566,7 @@ function parseRoutingMetadata(value: unknown): Record<string, unknown> | undefin
 
 function mapRoutingError(error: unknown): HttpError | undefined {
 	if (!(error instanceof Error)) return undefined;
-	const message = error.message ?? '';
+	const message = error.message;
 	if (message === 'routing_policy:not_loaded') {
 		return new HttpError(503, 'Routing policy not loaded', 'ROUTING_POLICY_NOT_LOADED');
 	}

--- a/apps/cortex-os/src/runtime.ts
+++ b/apps/cortex-os/src/runtime.ts
@@ -46,8 +46,6 @@ export async function startRuntime(): Promise<RuntimeHandle> {
 
 	const _memories = memories;
 
-	const _orchestration = orchestration;
-
 	const publish = wiring.publish;
 
 	const envSchema = z.object({
@@ -73,6 +71,7 @@ export async function startRuntime(): Promise<RuntimeHandle> {
 		profiles: profileRepository,
 		artifacts: artifactRepository,
 		evidence: evidenceRepository,
+		orchestration,
 	});
 	const eventManager = createEventManager({ httpServer });
 

--- a/libs/typescript/contracts/src/index.ts
+++ b/libs/typescript/contracts/src/index.ts
@@ -84,6 +84,13 @@ export * from './memory-events.js';
 export * from './memory-realtime.js';
 export * from './model-gateway-events.js';
 export * from './observability-events.js';
+export {
+        RoutingPolicySchema,
+        type RoutingCondition,
+        type RoutingInterface,
+        type RoutingPolicy,
+        type RoutingPriorityRule,
+} from './orchestration/routing-policy.js';
 // nO Intelligence Scheduler contracts (used by orchestration tests)
 export * from './orchestration-no/intelligence-scheduler.js';
 export * from './rag-events.js';

--- a/libs/typescript/contracts/src/orchestration/routing-policy.ts
+++ b/libs/typescript/contracts/src/orchestration/routing-policy.ts
@@ -1,0 +1,164 @@
+import { z } from 'zod';
+
+const networkPreferenceSchema = z.union([z.boolean(), z.literal('ask')]);
+const fileWriteScopeSchema = z.enum(['workspace_only', 'tempdir', 'forbid']);
+
+const safetyPolicySchema = z
+        .object({
+                allow_network: networkPreferenceSchema,
+                allow_fs_write: fileWriteScopeSchema,
+                sandbox: z.string().min(1).optional(),
+        })
+        .strict();
+
+const safetyOverrideSchema = z
+        .object({
+                allow_network: networkPreferenceSchema.optional(),
+                allow_fs_write: fileWriteScopeSchema.optional(),
+                sandbox: z.string().min(1).optional(),
+        })
+        .strict();
+
+const interfaceLocatorSchema = z
+        .object({
+                app: z.string().min(1).optional(),
+                pkg: z.string().min(1).optional(),
+                priority_base: z.number().int().min(0),
+                safety: safetyPolicySchema,
+        })
+        .strict()
+        .superRefine((value, ctx) => {
+                if (!value.app && !value.pkg) {
+                        ctx.addIssue({
+                                code: z.ZodIssueCode.custom,
+                                path: ['app'],
+                                message: 'interface locator must include either app or pkg field',
+                        });
+                }
+        });
+
+const routingConditionSchema = z
+        .object({
+                interface: z.string().min(1).optional(),
+                source: z.string().min(1).optional(),
+                env: z.string().min(1).optional(),
+                operation: z.string().min(1).optional(),
+                operation_any: z.array(z.string().min(1)).optional(),
+                tags_any: z.array(z.string().min(1)).optional(),
+                command_prefix_any: z.array(z.string().min(1)).optional(),
+                path_not_in: z.array(z.string().min(1)).optional(),
+        })
+        .strict();
+
+const ruleActionSchema = z
+        .object({
+                boost: z.number().int().optional(),
+                prefer_capabilities: z.array(z.string().min(1)).optional(),
+                require_approval: z.boolean().optional(),
+                safety_override: safetyOverrideSchema.optional(),
+        })
+        .strict();
+
+const priorityRuleSchema = z
+        .object({
+                id: z.string().min(1),
+                if: routingConditionSchema.default({}),
+                then: ruleActionSchema,
+        })
+        .strict();
+
+const capabilityProviderSchema = z
+        .object({
+                id: z.string().min(1),
+                providers: z.array(z.string().min(1)).min(1),
+        })
+        .strict();
+
+const incompatibleCapabilitySchema = z
+        .object({
+                id: z.string().min(1),
+                disallow_providers: z.array(z.string().min(1)).min(1),
+        })
+        .strict();
+
+const routingStrategySchema = z
+        .object({
+                plan_with: z.string().min(1),
+                select_by: z.array(z.string().min(1)).min(1),
+                fallbacks: z.array(z.string().min(1)).default([]),
+                guardrails: z.string().min(1),
+                evidence: z
+                        .object({
+                                require_provenance: z.boolean(),
+                                sink: z.string().min(1),
+                        })
+                        .strict(),
+        })
+        .strict();
+
+const approvalDecisionSchema = z
+        .object({
+                require_approval: z.boolean(),
+                approvers: z.array(z.string().min(1)).optional(),
+        })
+        .strict();
+
+const approvalPolicySchema = z
+        .object({
+                id: z.string().min(1),
+                if: routingConditionSchema.default({}),
+                then: approvalDecisionSchema,
+        })
+        .strict();
+
+const telemetryPolicySchema = z
+        .object({
+                otel_spans: z.boolean(),
+                a2a_events_topic: z.string().min(1),
+                redact: z
+                        .object({
+                                fields: z.array(z.string().min(1)).default([]),
+                        })
+                        .strict()
+                        .optional(),
+        })
+        .strict();
+
+export const RoutingPolicySchema = z
+        .object({
+                version: z.string().min(1),
+                metadata: z
+                        .object({
+                                owner: z.string().min(1),
+                                description: z.string().min(1),
+                                last_review: z.string().min(1).optional(),
+                        })
+                        .strict()
+                        .optional(),
+                interfaces: z.record(interfaceLocatorSchema),
+                priority_rules: z.array(priorityRuleSchema).optional(),
+                routing: z
+                        .object({
+                                strategy: routingStrategySchema,
+                        })
+                        .strict(),
+                capability_matrix: z
+                        .object({
+                                required: z.array(capabilityProviderSchema).min(1),
+                                incompatible: z.array(incompatibleCapabilitySchema).default([]),
+                        })
+                        .strict(),
+                approvals: z
+                        .object({
+                                policies: z.array(approvalPolicySchema).default([]),
+                        })
+                        .strict()
+                        .optional(),
+                telemetry: telemetryPolicySchema.optional(),
+        })
+        .strict();
+
+export type RoutingPolicy = z.infer<typeof RoutingPolicySchema>;
+export type RoutingInterface = z.infer<typeof interfaceLocatorSchema>;
+export type RoutingPriorityRule = z.infer<typeof priorityRuleSchema>;
+export type RoutingCondition = z.infer<typeof routingConditionSchema>;

--- a/libs/typescript/contracts/tests/routing-policy.contract.test.ts
+++ b/libs/typescript/contracts/tests/routing-policy.contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { RoutingPolicySchema } from '../src/orchestration/routing-policy.js';
+
+describe('RoutingPolicySchema', () => {
+        it('validates a minimal capability routing policy', () => {
+                const policy = RoutingPolicySchema.parse({
+                        version: '0.4',
+                        interfaces: {
+                                cli: {
+                                        app: 'apps/cortex-os',
+                                        priority_base: 80,
+                                        safety: {
+                                                allow_network: true,
+                                                allow_fs_write: 'workspace_only',
+                                        },
+                                },
+                        },
+                        routing: {
+                                strategy: {
+                                        plan_with: 'packages/orchestration/planners/policy-driven',
+                                        select_by: ['capability_score'],
+                                        fallbacks: ['packages/agents/generalist'],
+                                        guardrails: 'packages/security/policies/llm-guardrails.yaml',
+                                        evidence: {
+                                                require_provenance: true,
+                                                sink: 'packages/memories',
+                                        },
+                                },
+                        },
+                        capability_matrix: {
+                                required: [
+                                        {
+                                                id: 'code_edit',
+                                                providers: ['packages/agents/dev'],
+                                        },
+                                ],
+                                incompatible: [],
+                        },
+                });
+
+                expect(policy.capability_matrix.required[0]?.id).toBe('code_edit');
+        });
+
+        it('rejects policies with missing interface locator', () => {
+                expect(() =>
+                        RoutingPolicySchema.parse({
+                                version: '0.4',
+                                interfaces: {
+                                        webui: {
+                                                priority_base: 10,
+                                                safety: {
+                                                        allow_network: 'ask',
+                                                        allow_fs_write: 'tempdir',
+                                                },
+                                        },
+                                },
+                                routing: {
+                                        strategy: {
+                                                plan_with: 'packages/orchestration/planners/policy-driven',
+                                                select_by: ['capability_score'],
+                                                fallbacks: [],
+                                                guardrails: 'packages/security/policies/llm-guardrails.yaml',
+                                                evidence: {
+                                                        require_provenance: true,
+                                                        sink: 'packages/memories',
+                                                },
+                                        },
+                                },
+                                capability_matrix: {
+                                        required: [
+                                                {
+                                                        id: 'code_edit',
+                                                        providers: ['packages/agents/dev'],
+                                                },
+                                        ],
+                                },
+                        }),
+                ).toThrow(/app/);
+        });
+});

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:fuzz": "vitest run -c vitest.fuzz.config.ts",
     "generate:tests": "node scripts/ai-test-generator.mjs",
     "test:policy": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" VITEST_MAX_THREADS=2 VITEST_MIN_THREADS=1 VITEST_MAX_FORKS=2 VITEST_MIN_FORKS=1 vitest run -c vitest.policy.config.ts",
+    "policy:generate-routing": "node scripts/policies/generate-routing-policy-schema.cjs",
     "test:launch": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" VITEST_MAX_THREADS=2 VITEST_MIN_THREADS=1 VITEST_MAX_FORKS=2 VITEST_MIN_FORKS=1 vitest run -c tests/launch-readiness/vitest.config.ts",
     "ci:launch": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" vitest run -c vitest.launch.config.ts --reporter=dot",
     "test:gitmcp": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" VITEST_MAX_THREADS=2 VITEST_MIN_THREADS=1 VITEST_MAX_FORKS=2 VITEST_MIN_FORKS=1 vitest run -c vitest.gitmcp.config.ts",

--- a/packages/a2a/a2a-events/src/cortex/__tests__/routing-events.test.ts
+++ b/packages/a2a/a2a-events/src/cortex/__tests__/routing-events.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+        RoutingDecisionEventSchema,
+        RoutingFallbackEventSchema,
+        RoutingPlanEventSchema,
+} from '../routing-events.js';
+
+describe('cortex routing events', () => {
+        it('validates routing plan schema', () => {
+                const event = RoutingPlanEventSchema.parse({
+                        event_id: '00000000-0000-4000-8000-000000000001',
+                        event_type: 'cortex.routing.plan',
+                        source: 'cortex-orchestration',
+                        timestamp: new Date().toISOString(),
+                        requestId: 'req-123',
+                        interfaceId: 'cli',
+                        capabilities: ['code_edit'],
+                        tags: ['dev'],
+                        candidates: [{ agent: 'packages/agents/dev', score: 90, reasons: ['base'] }],
+                        appliedRules: [],
+                });
+                expect(event.candidates[0]?.agent).toBe('packages/agents/dev');
+        });
+
+        it('enforces approval structure on decision events', () => {
+                const decision = RoutingDecisionEventSchema.parse({
+                        event_id: '00000000-0000-4000-8000-000000000002',
+                        event_type: 'cortex.routing.decision',
+                        source: 'cortex-orchestration',
+                        timestamp: new Date().toISOString(),
+                        requestId: 'req-456',
+                        interfaceId: 'cli',
+                        policyVersion: '0.4',
+                        selectedAgent: 'packages/agents/dev',
+                        candidates: [{ agent: 'packages/agents/dev', score: 95, reasons: ['capability:code_edit'] }],
+                        appliedRules: [],
+                        approval: { required: false, approvers: [], policies: [] },
+                });
+                expect(decision.selectedAgent).toContain('agents');
+        });
+
+        it('rejects fallback events missing reason', () => {
+                expect(() =>
+                        RoutingFallbackEventSchema.parse({
+                                event_id: '00000000-0000-4000-8000-000000000003',
+                                event_type: 'cortex.routing.fallback',
+                                source: 'cortex-orchestration',
+                                timestamp: new Date().toISOString(),
+                                requestId: 'req-789',
+                                interfaceId: 'cli',
+                                agent: 'packages/agents/generalist',
+                        }),
+                ).toThrow();
+        });
+});

--- a/packages/a2a/a2a-events/src/cortex/index.ts
+++ b/packages/a2a/a2a-events/src/cortex/index.ts
@@ -6,6 +6,7 @@ export * from './agent-events';
 export * from './api-events.js';
 export * from './mcp-events.js';
 export * from './rag-events';
+export * from './routing-events.js';
 
 // Routing and Utilities
 export * from './routing';

--- a/packages/a2a/a2a-events/src/cortex/routing-events.ts
+++ b/packages/a2a/a2a-events/src/cortex/routing-events.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+const CORTEX_ROUTING_SOURCE = 'cortex-orchestration';
+
+const RoutingCandidateSchema = z
+        .object({
+                agent: z.string(),
+                score: z.number(),
+                reasons: z.array(z.string()),
+        })
+        .strict();
+
+export const RoutingPlanEventSchema = z
+        .object({
+                event_id: z.string().uuid(),
+                event_type: z.literal('cortex.routing.plan'),
+                source: z.literal(CORTEX_ROUTING_SOURCE),
+                timestamp: z.string().datetime(),
+                requestId: z.string(),
+                interfaceId: z.string(),
+                capabilities: z.array(z.string()),
+                tags: z.array(z.string()),
+                candidates: z.array(RoutingCandidateSchema),
+                appliedRules: z.array(z.string()),
+        })
+        .strict();
+
+export type RoutingPlanEvent = z.infer<typeof RoutingPlanEventSchema>;
+
+export const RoutingDecisionEventSchema = z
+        .object({
+                event_id: z.string().uuid(),
+                event_type: z.literal('cortex.routing.decision'),
+                source: z.literal(CORTEX_ROUTING_SOURCE),
+                timestamp: z.string().datetime(),
+                requestId: z.string(),
+                interfaceId: z.string(),
+                policyVersion: z.string(),
+                selectedAgent: z.string(),
+                candidates: z.array(RoutingCandidateSchema),
+                appliedRules: z.array(z.string()),
+                approval: z
+                        .object({
+                                required: z.boolean(),
+                                approvers: z.array(z.string()),
+                                policies: z.array(z.string()),
+                        })
+                        .strict(),
+        })
+        .strict();
+
+export type RoutingDecisionEvent = z.infer<typeof RoutingDecisionEventSchema>;
+
+export const RoutingFallbackEventSchema = z
+        .object({
+                event_id: z.string().uuid(),
+                event_type: z.literal('cortex.routing.fallback'),
+                source: z.literal(CORTEX_ROUTING_SOURCE),
+                timestamp: z.string().datetime(),
+                requestId: z.string(),
+                interfaceId: z.string(),
+                agent: z.string(),
+                reason: z.string(),
+        })
+        .strict();
+
+export type RoutingFallbackEvent = z.infer<typeof RoutingFallbackEventSchema>;

--- a/packages/a2a/a2a-events/src/index.ts
+++ b/packages/a2a/a2a-events/src/index.ts
@@ -11,8 +11,9 @@ export {
 // Core types and functions
 export type { A2AEventEnvelope } from './types.js';
 export {
-	A2AEventEnvelopeSchema,
-	createA2AEventEnvelope,
-	isA2AEventEnvelope,
-	validateA2AEventEnvelope,
+        A2AEventEnvelopeSchema,
+        createA2AEventEnvelope,
+        isA2AEventEnvelope,
+        validateA2AEventEnvelope,
 } from './types.js';
+export * from './cortex/index.js';

--- a/packages/mcp/src/server/auth-server.ts
+++ b/packages/mcp/src/server/auth-server.ts
@@ -1,16 +1,20 @@
+import type { PolicyRouter } from '@cortex-os/orchestration';
+
 import { createJWTAuth, type JWTAuth } from '../auth/jwt-auth.js';
 import { HTTPException } from '../errors';
 import { Server } from '../server';
+import { createRoutingTools } from './routing-tools.js';
 
 interface AuthServerConfig {
-	jwt?: JWTAuth;
-	requireAuth?: boolean;
-	allowedOrigins?: string[];
-	rateLimit?: {
-		enabled: boolean;
-		windowMs: number;
-		max: number;
-	};
+        jwt?: JWTAuth;
+        requireAuth?: boolean;
+        allowedOrigins?: string[];
+        rateLimit?: {
+                enabled: boolean;
+                windowMs: number;
+                max: number;
+        };
+        router?: PolicyRouter;
 }
 
 export class AuthServer extends Server {
@@ -20,14 +24,20 @@ export class AuthServer extends Server {
 	private rateLimit: AuthServerConfig['rateLimit'];
 	private rateLimitStore: Map<string, { count: number; resetTime: number }> = new Map();
 
-	constructor(config: AuthServerConfig = {}) {
-		super();
+        constructor(config: AuthServerConfig = {}) {
+                super();
 
-		this.jwt = config.jwt || createJWTAuth();
-		this.requireAuth = config.requireAuth ?? true;
-		this.allowedOrigins = config.allowedOrigins || ['*'];
-		this.rateLimit = config.rateLimit || { enabled: true, windowMs: 60000, max: 100 };
-	}
+                this.jwt = config.jwt || createJWTAuth();
+                this.requireAuth = config.requireAuth ?? true;
+                this.allowedOrigins = config.allowedOrigins || ['*'];
+                this.rateLimit = config.rateLimit || { enabled: true, windowMs: 60000, max: 100 };
+
+                if (config.router) {
+                        for (const tool of createRoutingTools(config.router)) {
+                                this.registerTool(tool);
+                        }
+                }
+        }
 
 	/**
 	 * Override handleRequest to add authentication

--- a/packages/mcp/src/server/routing-tools.ts
+++ b/packages/mcp/src/server/routing-tools.ts
@@ -1,0 +1,68 @@
+import type { PolicyRouter } from '@cortex-os/orchestration';
+
+interface RoutingToolInput {
+        interfaceId: string;
+        capabilities?: string[];
+        tags?: string[];
+        source?: string;
+}
+
+interface RoutingExplainInput {
+        requestId: string;
+}
+
+export function createRoutingTools(router: PolicyRouter) {
+        return [
+                {
+                        name: 'routing.dryRun',
+                        description: 'Preview a routing decision for a given interface and capability set.',
+                        inputSchema: {
+                                type: 'object',
+                                properties: {
+                                        interfaceId: { type: 'string' },
+                                        capabilities: { type: 'array', items: { type: 'string' }, default: [] },
+                                        tags: { type: 'array', items: { type: 'string' }, default: [] },
+                                        source: { type: 'string', default: 'mcp' },
+                                },
+                                required: ['interfaceId'],
+                        },
+                        handler: async (params: RoutingToolInput) => {
+                                const decision = await router.route({
+                                        interfaceId: params.interfaceId,
+                                        capabilities: params.capabilities ?? [],
+                                        tags: params.tags ?? [],
+                                        source: params.source ?? 'mcp',
+                                });
+                                return {
+                                        requestId: decision.requestId,
+                                        selectedAgent: decision.selectedAgent,
+                                        candidates: decision.candidates,
+                                        approval: decision.approval,
+                                        appliedRules: decision.appliedRules,
+                                        policyVersion: decision.policyVersion,
+                                };
+                        },
+                },
+                {
+                        name: 'routing.explain',
+                        description: 'Explain a routing decision captured earlier.',
+                        inputSchema: {
+                                type: 'object',
+                                properties: {
+                                        requestId: { type: 'string' },
+                                },
+                                required: ['requestId'],
+                        },
+                        handler: async (params: RoutingExplainInput) => {
+                                const decision = router.explain(params.requestId);
+                                if (!decision) {
+                                        return { found: false };
+                                }
+                                return {
+                                        found: true,
+                                        decision,
+                                };
+                        },
+                },
+        ];
+}

--- a/packages/mcp/src/test/routing-tools.test.ts
+++ b/packages/mcp/src/test/routing-tools.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createRoutingTools } from '../server/routing-tools.js';
+
+describe('routing tools', () => {
+        it('invokes router for dry runs and explanations', async () => {
+                const mockDecision = {
+                        requestId: 'req-1',
+                        interfaceId: 'cli',
+                        policyVersion: '0.4',
+                        request: {
+                                requestId: 'req-1',
+                                interfaceId: 'cli',
+                                capabilities: ['code_edit'],
+                                tags: [],
+                                source: 'test',
+                                command: '',
+                                env: 'development',
+                                operation: 'read_only',
+                                metadata: {},
+                        },
+                        selectedAgent: 'packages/agents/dev',
+                        candidates: [],
+                        appliedRules: [],
+                        approval: { required: false, approvers: [], policies: [] },
+                        fallback: null,
+                        createdAt: new Date().toISOString(),
+                };
+                const router = {
+                        route: vi.fn().mockResolvedValue(mockDecision),
+                        explain: vi.fn().mockReturnValue(mockDecision),
+                } as unknown as import('@cortex-os/orchestration').PolicyRouter;
+                const [dryRun, explain] = createRoutingTools(router);
+
+                const dryRunResult = await dryRun.handler({ interfaceId: 'cli', capabilities: ['code_edit'] });
+                expect(router.route).toHaveBeenCalledWith({
+                        interfaceId: 'cli',
+                        capabilities: ['code_edit'],
+                        tags: [],
+                        source: 'mcp',
+                });
+                expect(dryRunResult.selectedAgent).toBe('packages/agents/dev');
+
+                const explainResult = await explain.handler({ requestId: 'req-1' });
+                expect(router.explain).toHaveBeenCalledWith('req-1');
+                expect(explainResult.found).toBe(true);
+        });
+
+        it('returns not found when explain misses', async () => {
+                const router = {
+                        route: vi.fn(),
+                        explain: vi.fn().mockReturnValue(undefined),
+                } as unknown as import('@cortex-os/orchestration').PolicyRouter;
+                const [, explain] = createRoutingTools(router);
+                const result = await explain.handler({ requestId: 'missing' });
+                expect(result.found).toBe(false);
+        });
+});

--- a/packages/orchestration/__tests__/public-exports.snapshot.test.ts
+++ b/packages/orchestration/__tests__/public-exports.snapshot.test.ts
@@ -23,6 +23,7 @@ describe('@cortex-os/orchestration public API', () => {
       "ORCHESTRATION_EVENT_SCHEMAS",
       "OrchestrationDefaults",
       "OrchestrationEventTypes",
+      "PolicyRouter",
       "SecurityCoordinator",
       "THERMAL_CTX_KEY",
       "ThermalEventSchema",

--- a/packages/orchestration/src/events/orchestration-bus.ts
+++ b/packages/orchestration/src/events/orchestration-bus.ts
@@ -4,41 +4,49 @@ import type { Transport } from '@cortex-os/a2a-core/transport';
 import { inproc } from '@cortex-os/a2a-transport/inproc';
 
 import {
-	type AgentAssignedEvent,
-	type AgentCoordinationStartedEvent,
-	type AgentFreedEvent,
-	type CoordinationStartedEvent,
-	type DecisionMadeEvent,
-	ORCHESTRATION_EVENT_SCHEMAS,
-	type OrchestrationEventType,
-	OrchestrationEventTypes,
-	type PlanCreatedEvent,
-	type PlanUpdatedEvent,
-	type ResourceAllocatedEvent,
-	type ScheduleAdjustedEvent,
-	type TaskCompletedEvent,
-	type TaskCreatedEvent,
-	type TaskFailedEvent,
-	type TaskStartedEvent,
-	type ToolLayerInvokedEvent,
+        type AgentAssignedEvent,
+        type AgentCoordinationStartedEvent,
+        type AgentFreedEvent,
+        type CoordinationStartedEvent,
+        type DecisionMadeEvent,
+        ORCHESTRATION_EVENT_SCHEMAS,
+        type OrchestrationEventType,
+        OrchestrationEventTypes,
+        type PlanCreatedEvent,
+        type PlanUpdatedEvent,
+        type ResourceAllocatedEvent,
+        type ScheduleAdjustedEvent,
+        type TaskCompletedEvent,
+        type TaskCreatedEvent,
+        type TaskFailedEvent,
+        type TaskStartedEvent,
+        type ToolLayerInvokedEvent,
 } from './orchestration-events.js';
+import type {
+        RoutingDecisionEvent,
+        RoutingFallbackEvent,
+        RoutingPlanEvent,
+} from './routing-events.js';
 
 type OrchestrationEventPayloadMap = {
-	[OrchestrationEventTypes.TaskCreated]: TaskCreatedEvent;
-	[OrchestrationEventTypes.TaskStarted]: TaskStartedEvent;
-	[OrchestrationEventTypes.TaskCompleted]: TaskCompletedEvent;
-	[OrchestrationEventTypes.TaskFailed]: TaskFailedEvent;
-	[OrchestrationEventTypes.AgentAssigned]: AgentAssignedEvent;
-	[OrchestrationEventTypes.AgentFreed]: AgentFreedEvent;
-	[OrchestrationEventTypes.PlanCreated]: PlanCreatedEvent;
-	[OrchestrationEventTypes.PlanUpdated]: PlanUpdatedEvent;
-	[OrchestrationEventTypes.CoordinationStarted]: CoordinationStartedEvent;
-	[OrchestrationEventTypes.DecisionMade]: DecisionMadeEvent;
-	[OrchestrationEventTypes.ResourceAllocated]: ResourceAllocatedEvent;
-	// nO Architecture Events
-	[OrchestrationEventTypes.AgentCoordinationStarted]: AgentCoordinationStartedEvent;
-	[OrchestrationEventTypes.ScheduleAdjusted]: ScheduleAdjustedEvent;
-	[OrchestrationEventTypes.ToolLayerInvoked]: ToolLayerInvokedEvent;
+        [OrchestrationEventTypes.TaskCreated]: TaskCreatedEvent;
+        [OrchestrationEventTypes.TaskStarted]: TaskStartedEvent;
+        [OrchestrationEventTypes.TaskCompleted]: TaskCompletedEvent;
+        [OrchestrationEventTypes.TaskFailed]: TaskFailedEvent;
+        [OrchestrationEventTypes.AgentAssigned]: AgentAssignedEvent;
+        [OrchestrationEventTypes.AgentFreed]: AgentFreedEvent;
+        [OrchestrationEventTypes.PlanCreated]: PlanCreatedEvent;
+        [OrchestrationEventTypes.PlanUpdated]: PlanUpdatedEvent;
+        [OrchestrationEventTypes.CoordinationStarted]: CoordinationStartedEvent;
+        [OrchestrationEventTypes.DecisionMade]: DecisionMadeEvent;
+        [OrchestrationEventTypes.ResourceAllocated]: ResourceAllocatedEvent;
+        [OrchestrationEventTypes.RoutingPlan]: RoutingPlanEvent;
+        [OrchestrationEventTypes.RoutingDecision]: RoutingDecisionEvent;
+        [OrchestrationEventTypes.RoutingFallback]: RoutingFallbackEvent;
+        // nO Architecture Events
+        [OrchestrationEventTypes.AgentCoordinationStarted]: AgentCoordinationStartedEvent;
+        [OrchestrationEventTypes.ScheduleAdjusted]: ScheduleAdjustedEvent;
+        [OrchestrationEventTypes.ToolLayerInvoked]: ToolLayerInvokedEvent;
 };
 
 export type OrchestrationEventEnvelope<

--- a/packages/orchestration/src/events/orchestration-events.ts
+++ b/packages/orchestration/src/events/orchestration-events.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
+import {
+        RoutingDecisionEventSchema,
+        RoutingFallbackEventSchema,
+        RoutingPlanEventSchema,
+} from './routing-events.js';
+
 export const OrchestrationEventTypes = {
 	TaskCreated: 'orchestration.task.created',
 	TaskStarted: 'orchestration.task.started',
@@ -7,13 +13,16 @@ export const OrchestrationEventTypes = {
 	TaskFailed: 'orchestration.task.failed',
 	AgentAssigned: 'orchestration.agent.assigned',
 	AgentFreed: 'orchestration.agent.freed',
-	PlanCreated: 'orchestration.plan.created',
-	PlanUpdated: 'orchestration.plan.updated',
-	CoordinationStarted: 'orchestration.coordination.started',
-	DecisionMade: 'orchestration.decision.made',
-	ResourceAllocated: 'orchestration.resource.allocated',
-	// nO Architecture Events
-	AgentCoordinationStarted: 'agent_coordination_started',
+        PlanCreated: 'orchestration.plan.created',
+        PlanUpdated: 'orchestration.plan.updated',
+        CoordinationStarted: 'orchestration.coordination.started',
+        DecisionMade: 'orchestration.decision.made',
+        ResourceAllocated: 'orchestration.resource.allocated',
+        RoutingPlan: 'orchestration.routing.plan',
+        RoutingDecision: 'orchestration.routing.decision',
+        RoutingFallback: 'orchestration.routing.fallback',
+        // nO Architecture Events
+        AgentCoordinationStarted: 'agent_coordination_started',
 	ScheduleAdjusted: 'schedule_adjusted',
 	ToolLayerInvoked: 'tool_layer_invoked',
 } as const;
@@ -203,13 +212,16 @@ export const ORCHESTRATION_EVENT_SCHEMAS = {
 	[OrchestrationEventTypes.TaskFailed]: taskFailedEventSchema,
 	[OrchestrationEventTypes.AgentAssigned]: agentAssignedEventSchema,
 	[OrchestrationEventTypes.AgentFreed]: agentFreedEventSchema,
-	[OrchestrationEventTypes.PlanCreated]: planCreatedEventSchema,
-	[OrchestrationEventTypes.PlanUpdated]: planUpdatedEventSchema,
-	[OrchestrationEventTypes.CoordinationStarted]: coordinationStartedEventSchema,
-	[OrchestrationEventTypes.DecisionMade]: decisionMadeEventSchema,
-	[OrchestrationEventTypes.ResourceAllocated]: resourceAllocatedEventSchema,
-	// nO Architecture Event Schemas
-	[OrchestrationEventTypes.AgentCoordinationStarted]: agentCoordinationStartedEventSchema,
+        [OrchestrationEventTypes.PlanCreated]: planCreatedEventSchema,
+        [OrchestrationEventTypes.PlanUpdated]: planUpdatedEventSchema,
+        [OrchestrationEventTypes.CoordinationStarted]: coordinationStartedEventSchema,
+        [OrchestrationEventTypes.DecisionMade]: decisionMadeEventSchema,
+        [OrchestrationEventTypes.ResourceAllocated]: resourceAllocatedEventSchema,
+        [OrchestrationEventTypes.RoutingPlan]: RoutingPlanEventSchema,
+        [OrchestrationEventTypes.RoutingDecision]: RoutingDecisionEventSchema,
+        [OrchestrationEventTypes.RoutingFallback]: RoutingFallbackEventSchema,
+        // nO Architecture Event Schemas
+        [OrchestrationEventTypes.AgentCoordinationStarted]: agentCoordinationStartedEventSchema,
 	[OrchestrationEventTypes.ScheduleAdjusted]: scheduleAdjustedEventSchema,
 	[OrchestrationEventTypes.ToolLayerInvoked]: toolLayerInvokedEventSchema,
 } as const;

--- a/packages/orchestration/src/events/routing-events.ts
+++ b/packages/orchestration/src/events/routing-events.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+const candidateSchema = z
+        .object({
+                agent: z.string(),
+                score: z.number(),
+                reasons: z.array(z.string()),
+        })
+        .strict();
+
+export const RoutingPlanEventSchema = z
+        .object({
+                requestId: z.string(),
+                interfaceId: z.string(),
+                capabilities: z.array(z.string()),
+                tags: z.array(z.string()),
+                candidates: z.array(candidateSchema),
+                appliedRules: z.array(z.string()),
+        })
+        .strict();
+
+export type RoutingPlanEvent = z.infer<typeof RoutingPlanEventSchema>;
+
+export const RoutingDecisionEventSchema = z
+        .object({
+                requestId: z.string(),
+                interfaceId: z.string(),
+                policyVersion: z.string(),
+                selectedAgent: z.string(),
+                candidates: z.array(candidateSchema),
+                appliedRules: z.array(z.string()),
+                approval: z
+                        .object({
+                                required: z.boolean(),
+                                approvers: z.array(z.string()),
+                                policies: z.array(z.string()),
+                        })
+                        .strict(),
+                timestamp: z.string(),
+        })
+        .strict();
+
+export type RoutingDecisionEvent = z.infer<typeof RoutingDecisionEventSchema>;
+
+export const RoutingFallbackEventSchema = z
+        .object({
+                requestId: z.string(),
+                interfaceId: z.string(),
+                agent: z.string(),
+                reason: z.string(),
+                timestamp: z.string(),
+        })
+        .strict();
+
+export type RoutingFallbackEvent = z.infer<typeof RoutingFallbackEventSchema>;
+
+export function createRoutingPlanEvent(event: RoutingPlanEvent): RoutingPlanEvent {
+        return RoutingPlanEventSchema.parse(event);
+}
+
+export function createRoutingDecisionEvent(event: RoutingDecisionEvent): RoutingDecisionEvent {
+        return RoutingDecisionEventSchema.parse(event);
+}
+
+export function createRoutingFallbackEvent(
+        requestId: string,
+        interfaceId: string,
+        agent: string,
+        reason: string,
+): RoutingFallbackEvent {
+        return RoutingFallbackEventSchema.parse({
+                requestId,
+                interfaceId,
+                agent,
+                reason,
+                timestamp: new Date().toISOString(),
+        });
+}

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -93,14 +93,21 @@ export {
 	createUnifiedToolSystem,
 } from './langgraph/tool-system.js';
 export {
-	type ComplianceEvaluationResult,
-	SecurityCoordinator,
+        type ComplianceEvaluationResult,
+        SecurityCoordinator,
 } from './security/security-coordinator.js';
 export {
-	type OrchestrationFacade,
-	OrchestrationService,
-	provideOrchestration,
+        type OrchestrationFacade,
+        OrchestrationService,
+        provideOrchestration,
 } from './service.js';
+export { PolicyRouter } from './routing/policy-router.js';
+export type {
+        RoutingApproval,
+        RoutingCandidate,
+        RoutingDecision,
+        RoutingRequest,
+} from './types.js';
 
 // Utility defaults
 export const OrchestrationDefaults = {

--- a/packages/orchestration/src/langgraph/create-cerebrum-graph.ts
+++ b/packages/orchestration/src/langgraph/create-cerebrum-graph.ts
@@ -1,6 +1,8 @@
 import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
 import type { NoTelemetryEvent } from '../observability/no-telemetry-contracts.js';
 import { createNoTelemetryEvent } from '../observability/no-telemetry-contracts.js';
+import type { PolicyRouter } from '../routing/policy-router.js';
+import type { RoutingDecision, RoutingRequest } from '../types.js';
 import {
 	type ThermalGuardPatch,
 	type ThermalGuardState,
@@ -19,8 +21,9 @@ import {
 } from './thermal/thermal-policy.js';
 
 export interface CerebrumGraphConfig {
-	thermalPolicy?: ThermalPolicy;
-	clock?: () => number;
+        routing?: PolicyRouter;
+        thermalPolicy?: ThermalPolicy;
+        clock?: () => number;
 }
 
 type ModelRef = {
@@ -32,8 +35,9 @@ type CerebrumState = typeof CerebrumAnnotation.State;
 type GuardedState = CerebrumState & ThermalGuardState;
 
 type RoutingContext = {
-	selectedProvider?: string;
-	decision?: string;
+        selectedProvider?: string;
+        decision?: RoutingDecision;
+        decisionLabel?: string;
 };
 
 type TelemetryContext = NoTelemetryEvent[];
@@ -73,11 +77,49 @@ function ensureBudget(state: CerebrumState): N0Budget {
 }
 
 function ensureTelemetry(ctx: Record<string, unknown> | undefined): TelemetryContext {
-	const telemetry = ctx?.telemetry;
-	if (Array.isArray(telemetry)) {
-		return [...(telemetry as TelemetryContext)];
-	}
-	return [];
+        const telemetry = ctx?.telemetry;
+        if (Array.isArray(telemetry)) {
+                return [...(telemetry as TelemetryContext)];
+        }
+        return [];
+}
+
+function extractStringArray(value: unknown): string[] {
+        if (!Array.isArray(value)) return [];
+        return value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function getString(value: unknown, fallback: string): string {
+        return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+async function resolveRoutingDecision(
+        router: PolicyRouter | undefined,
+        state: CerebrumState,
+): Promise<RoutingDecision | undefined> {
+        if (!router) return undefined;
+        const context = (state.ctx as Record<string, unknown> | undefined) ?? {};
+        const metadataCandidate = context.metadata;
+        const metadata =
+                metadataCandidate && typeof metadataCandidate === 'object'
+                        ? (metadataCandidate as Record<string, unknown>)
+                        : {};
+        const request: RoutingRequest = {
+                interfaceId: getString(context.interface ?? context.interfaceId, 'cli'),
+                capabilities: extractStringArray(context.capabilities),
+                tags: extractStringArray(context.tags),
+                source: getString(context.source, 'langgraph'),
+                command: getString(context.command, ''),
+                env: getString(context.env, 'development'),
+                operation: getString(context.operation, 'read_only'),
+                metadata,
+        };
+        try {
+                return await router.route(request);
+        } catch (error) {
+                console.warn('cerebrum routing decision failed', error);
+                return undefined;
+        }
 }
 
 function buildTelemetryEvent(
@@ -148,13 +190,14 @@ function createPausePatch(decision: ThermalDecision, state: N0State): ThermalGua
 		cooldownUntil: decision.cooldownUntil,
 	});
 	const existingTelemetry = ensureTelemetry(state.ctx);
-	const ctx: Record<string, unknown> = {
-		routing: {
-			...((state.ctx?.routing as RoutingContext | undefined) ?? {}),
-			decision: 'thermal-fallback',
-			selectedProvider: 'ollama.brainwav-fallback',
-		},
-	};
+        const ctx: Record<string, unknown> = {
+                routing: {
+                        ...((state.ctx?.routing as RoutingContext | undefined) ?? {}),
+                        decision: undefined,
+                        decisionLabel: 'thermal-fallback',
+                        selectedProvider: 'ollama.brainwav-fallback',
+                },
+        };
 	if (telemetry) {
 		ctx.telemetry = [...existingTelemetry, telemetry];
 	}
@@ -171,13 +214,14 @@ function createResumePatch(state: N0State): ThermalGuardPatch {
 		paused: false,
 	});
 	const existingTelemetry = ensureTelemetry(state.ctx);
-	const ctx: Record<string, unknown> = {
-		routing: {
-			...((state.ctx?.routing as RoutingContext | undefined) ?? {}),
-			selectedProvider: 'mlx.brainwav-foundation',
-			decision: 'thermal-nominal',
-		},
-	};
+        const ctx: Record<string, unknown> = {
+                routing: {
+                        ...((state.ctx?.routing as RoutingContext | undefined) ?? {}),
+                        selectedProvider: 'mlx.brainwav-foundation',
+                        decision: undefined,
+                        decisionLabel: 'thermal-nominal',
+                },
+        };
 	if (telemetry) {
 		ctx.telemetry = [...existingTelemetry, telemetry];
 	}
@@ -191,21 +235,24 @@ export function createCerebrumGraph(config: CerebrumGraphConfig = {}) {
 	const policy = config.thermalPolicy ?? new ThermalPolicy();
 	const clock = config.clock ?? (() => Date.now());
 
-	const guardedSelect = withThermalGuard<GuardedState>(
-		async (state) => {
-			return {
-				selectedModel: {
-					provider: 'mlx',
-					model: 'brainwav-foundation',
-				},
-				ctx: {
-					routing: {
-						...((state.ctx?.routing as RoutingContext | undefined) ?? {}),
-						selectedProvider: 'mlx.brainwav-foundation',
-					},
-				},
-			};
-		},
+        const guardedSelect = withThermalGuard<GuardedState>(
+                async (state) => {
+                        const decision = await resolveRoutingDecision(config.routing, state);
+                        const previous = state.ctx?.routing as RoutingContext | undefined;
+                        const selectedProvider = decision?.selectedAgent ?? previous?.selectedProvider ?? 'mlx.brainwav-foundation';
+                        const decisionLabel = decision ? 'policy-router' : previous?.decisionLabel ?? 'thermal-default';
+                        return {
+                                selectedModel: { provider: 'mlx', model: 'brainwav-foundation' },
+                                ctx: {
+                                        routing: {
+                                                ...previous,
+                                                selectedProvider,
+                                                decision,
+                                                decisionLabel,
+                                        },
+                                },
+                        };
+                },
 		{
 			policy,
 			clock,

--- a/packages/orchestration/src/routing/policy-router.ts
+++ b/packages/orchestration/src/routing/policy-router.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { watch } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { RoutingPolicySchema, type RoutingPolicy } from '@cortex-os/contracts';
+import type { OrchestrationBus } from '../events/orchestration-bus.js';
+import { OrchestrationEventTypes } from '../events/orchestration-events.js';
+import {
+        createRoutingDecisionEvent,
+        createRoutingFallbackEvent,
+        createRoutingPlanEvent,
+        type RoutingDecisionEvent,
+        type RoutingFallbackEvent,
+        type RoutingPlanEvent,
+} from '../events/routing-events.js';
+import type { RoutingApproval, RoutingCandidate, RoutingDecision, RoutingRequest } from '../types.js';
+import yaml from 'yaml';
+
+interface CandidateState {
+        score: number;
+        capabilities: Set<string>;
+        reasons: string[];
+}
+
+interface StoredDecision {
+        decision: RoutingDecision;
+        recordedAt: string;
+}
+
+export interface PolicyRouterOptions {
+        bus?: OrchestrationBus;
+        logger?: Pick<Console, 'info' | 'warn' | 'error'>;
+        historyLimit?: number;
+}
+
+const DEFAULT_HISTORY_LIMIT = 200;
+
+export class PolicyRouter {
+        private policy: RoutingPolicy | undefined;
+        private readonly policyFile: string;
+        private readonly logger: Pick<Console, 'info' | 'warn' | 'error'>;
+        private readonly bus?: OrchestrationBus;
+        private readonly historyLimit: number;
+        private readonly history = new Map<string, StoredDecision>();
+        private readonly historyOrder: string[] = [];
+        private watcher: ReturnType<typeof watch> | undefined;
+        private loadPromise: Promise<void> | undefined;
+
+        constructor(policyPath: string, options: PolicyRouterOptions = {}) {
+                this.policyFile = resolve(policyPath);
+                this.logger = options.logger ?? console;
+                this.bus = options.bus;
+                this.historyLimit = Math.max(20, options.historyLimit ?? DEFAULT_HISTORY_LIMIT);
+                this.loadPromise = this.reloadPolicy();
+                this.startWatcher();
+        }
+
+        async route(request: RoutingRequest): Promise<RoutingDecision> {
+                const policy = await this.ensurePolicy();
+                const normalized = this.normalizeRequest(request);
+                const interfacePolicy = policy.interfaces[normalized.interfaceId];
+                if (!interfacePolicy) {
+                        throw new Error(`routing_policy:interface_missing:${normalized.interfaceId}`);
+                }
+
+                const plan = this.buildPlan(policy, normalized, interfacePolicy.priority_base);
+                await this.publishPlan(plan.planEvent);
+
+                const decision = this.composeDecision({
+                        policyVersion: policy.version,
+                        request: normalized,
+                        candidates: plan.candidates,
+                        appliedRules: plan.appliedRules,
+                        approval: plan.approval,
+                        fallbackAgent: policy.routing.strategy.fallbacks?.[0],
+                });
+
+                this.storeDecision(decision);
+                const decisionEvent = createRoutingDecisionEvent({
+                        requestId: decision.requestId,
+                        interfaceId: decision.interfaceId,
+                        policyVersion: decision.policyVersion,
+                        selectedAgent: decision.selectedAgent,
+                        candidates: decision.candidates,
+                        appliedRules: decision.appliedRules,
+                        approval: decision.approval,
+                        timestamp: decision.createdAt,
+                });
+                await this.publishDecision(decisionEvent);
+                if (decision.fallback) {
+                        await this.publishFallback(
+                                createRoutingFallbackEvent(
+                                        decision.requestId,
+                                        decision.interfaceId,
+                                        decision.fallback.agent,
+                                        decision.fallback.reason,
+                                ),
+                        );
+                }
+
+                return decision;
+        }
+
+        explain(requestId: string): RoutingDecision | undefined {
+                return this.history.get(requestId)?.decision;
+        }
+
+        async close(): Promise<void> {
+                        this.watcher?.close();
+                        this.watcher = undefined;
+        }
+
+        private async ensurePolicy(): Promise<RoutingPolicy> {
+                if (this.loadPromise) {
+                        await this.loadPromise;
+                        this.loadPromise = undefined;
+                }
+                if (!this.policy) {
+                        this.loadPromise = this.reloadPolicy();
+                        await this.loadPromise;
+                        this.loadPromise = undefined;
+                }
+                if (!this.policy) throw new Error('routing_policy:not_loaded');
+                return this.policy;
+        }
+
+        private startWatcher(): void {
+                try {
+                        this.watcher = watch(this.policyFile, { persistent: false }, () => {
+                                this.logger.info?.('routing policy change detected');
+                                this.loadPromise = this.reloadPolicy();
+                        });
+                } catch (error) {
+                        this.logger.warn?.(`routing policy watcher error: ${(error as Error).message}`);
+                }
+        }
+
+        private async reloadPolicy(): Promise<void> {
+                const data = await readFile(this.policyFile, 'utf8');
+                const parsed = yaml.parse(data);
+                this.policy = RoutingPolicySchema.parse(parsed);
+                this.logger.info?.('routing policy loaded');
+        }
+
+        private normalizeRequest(request: RoutingRequest): Required<RoutingRequest> {
+                return {
+                        requestId: request.requestId ?? randomUUID(),
+                        interfaceId: request.interfaceId,
+                        capabilities: [...new Set(request.capabilities ?? [])],
+                        tags: [...new Set(request.tags ?? [])],
+                        source: request.source ?? 'unknown',
+                        command: request.command ?? '',
+                        env: request.env ?? 'development',
+                        operation: request.operation ?? 'read_only',
+                        metadata: request.metadata ?? {},
+                };
+        }
+
+        private buildPlan(
+                policy: RoutingPolicy,
+                request: Required<RoutingRequest>,
+                priorityBase: number,
+        ): {
+                candidates: Map<string, CandidateState>;
+                appliedRules: string[];
+                approval: RoutingApproval;
+                planEvent: RoutingPlanEvent;
+        } {
+                const candidates = this.buildCandidates(policy, request, priorityBase);
+                const appliedRules = this.applyPriorityRules(policy, request, candidates);
+                const approval = this.evaluateApprovals(policy, request);
+                const planEvent = createRoutingPlanEvent({
+                        requestId: request.requestId,
+                        interfaceId: request.interfaceId,
+                        capabilities: request.capabilities,
+                        tags: request.tags,
+                        candidates: Array.from(candidates.entries()).map(([agent, state]) => ({
+                                agent,
+                                score: state.score,
+                                reasons: [...state.reasons],
+                        })),
+                        appliedRules,
+                });
+                return { candidates, appliedRules, approval, planEvent };
+        }
+
+        private buildCandidates(
+                policy: RoutingPolicy,
+                request: Required<RoutingRequest>,
+                priorityBase: number,
+        ): Map<string, CandidateState> {
+                const candidates = new Map<string, CandidateState>();
+                const disallowed = new Set<string>();
+                for (const constraint of policy.capability_matrix.incompatible ?? []) {
+                        if (request.capabilities.includes(constraint.id)) {
+                                for (const provider of constraint.disallow_providers) disallowed.add(provider);
+                        }
+                }
+                for (const capability of request.capabilities) {
+                        const mapping = policy.capability_matrix.required.find((item) => item.id === capability);
+                        if (!mapping) continue;
+                        for (const provider of mapping.providers) {
+                                if (disallowed.has(provider)) continue;
+                                const state = candidates.get(provider) ?? this.createCandidate(priorityBase);
+                                state.capabilities.add(capability);
+                                candidates.set(provider, state);
+                        }
+                }
+                if (candidates.size === 0) {
+                        for (const fallback of policy.routing.strategy.fallbacks ?? []) {
+                                if (disallowed.has(fallback)) continue;
+                                candidates.set(fallback, this.createCandidate(priorityBase, 'fallback-seed'));
+                        }
+                }
+                return candidates;
+        }
+
+        private createCandidate(score: number, reason?: string): CandidateState {
+                const reasons = reason ? [reason] : [];
+                return { score, capabilities: new Set(), reasons };
+        }
+
+        private applyPriorityRules(
+                policy: RoutingPolicy,
+                request: Required<RoutingRequest>,
+                candidates: Map<string, CandidateState>,
+        ): string[] {
+                const applied: string[] = [];
+                for (const rule of policy.priority_rules ?? []) {
+                        if (!this.matchesCondition(rule.if ?? {}, request)) continue;
+                        applied.push(rule.id);
+                        this.applyRuleEffects(rule.then, policy, candidates);
+                }
+                return applied;
+        }
+
+        private applyRuleEffects(
+                action: RoutingPolicy['priority_rules'][number]['then'],
+                policy: RoutingPolicy,
+                candidates: Map<string, CandidateState>,
+        ): void {
+                if (action.boost) {
+                        for (const state of candidates.values()) {
+                                state.score += action.boost;
+                                state.reasons.push(`boost:${action.boost}`);
+                        }
+                }
+                if (!action.prefer_capabilities) return;
+                for (const capability of action.prefer_capabilities) {
+                        const mapping = policy.capability_matrix.required.find((item) => item.id === capability);
+                        if (!mapping) continue;
+                        for (const provider of mapping.providers) {
+                                const state = candidates.get(provider);
+                                if (!state) continue;
+                                state.score += Math.max(action.boost ?? 0, 5);
+                                state.reasons.push(`prefer:${capability}`);
+                        }
+                }
+        }
+
+        private evaluateApprovals(policy: RoutingPolicy, request: Required<RoutingRequest>): RoutingApproval {
+                const result: RoutingApproval = { required: false, approvers: [], policies: [] };
+                const approvers = new Set<string>();
+                for (const policyRule of policy.approvals?.policies ?? []) {
+                        if (!this.matchesCondition(policyRule.if ?? {}, request)) continue;
+                        result.required = true;
+                        result.policies.push(policyRule.id);
+                        for (const person of policyRule.then.approvers ?? []) approvers.add(person);
+                }
+                result.approvers = [...approvers];
+                return result;
+        }
+
+        private matchesCondition(
+                condition: RoutingPolicy['priority_rules'][number]['if'],
+                request: Required<RoutingRequest>,
+        ): boolean {
+                if (condition.interface && condition.interface !== request.interfaceId) return false;
+                if (condition.source && condition.source !== request.source) return false;
+                if (condition.env && condition.env !== request.env) return false;
+                if (condition.operation && condition.operation !== request.operation) return false;
+                if (condition.operation_any && !condition.operation_any.includes(request.operation)) return false;
+                if (condition.tags_any) {
+                        const found = condition.tags_any.some((tag) => request.tags.includes(tag));
+                        if (!found) return false;
+                }
+                if (condition.command_prefix_any && request.command) {
+                        const match = condition.command_prefix_any.some((prefix) => request.command.startsWith(prefix));
+                        if (!match) return false;
+                }
+                if (condition.path_not_in) {
+                        const path = typeof request.metadata.path === 'string' ? request.metadata.path : undefined;
+                        if (path && condition.path_not_in.includes(path)) return false;
+                }
+                return true;
+        }
+
+        private composeDecision(args: {
+                policyVersion: string;
+                request: Required<RoutingRequest>;
+                candidates: Map<string, CandidateState>;
+                appliedRules: string[];
+                approval: RoutingApproval;
+                fallbackAgent?: string;
+        }): RoutingDecision {
+                const sorted = this.rankCandidates(args.candidates);
+                const selected = sorted[0];
+                const fallbackNeeded = !selected && args.fallbackAgent;
+                const fallback = fallbackNeeded
+                        ? { agent: args.fallbackAgent as string, reason: 'no-candidate' }
+                        : null;
+                const chosenAgent = selected?.agent ?? fallback?.agent ?? 'unassigned';
+                const createdAt = new Date().toISOString();
+
+                return {
+                        requestId: args.request.requestId,
+                        interfaceId: args.request.interfaceId,
+                        policyVersion: args.policyVersion,
+                        request: args.request,
+                        selectedAgent: chosenAgent,
+                        candidates: sorted,
+                        appliedRules: args.appliedRules,
+                        approval: args.approval,
+                        fallback,
+                        createdAt,
+                };
+        }
+
+        private rankCandidates(candidates: Map<string, CandidateState>): RoutingCandidate[] {
+                const ranked = Array.from(candidates.entries()).map(([agent, state]) => ({
+                        agent,
+                        score: state.score,
+                        capabilities: [...state.capabilities],
+                        reasons: [...state.reasons],
+                }));
+                ranked.sort((a, b) => b.score - a.score || a.agent.localeCompare(b.agent));
+                return ranked;
+        }
+
+        private storeDecision(decision: RoutingDecision): void {
+                this.history.set(decision.requestId, { decision, recordedAt: decision.createdAt });
+                this.historyOrder.push(decision.requestId);
+                while (this.historyOrder.length > this.historyLimit) {
+                        const oldest = this.historyOrder.shift();
+                        if (oldest) this.history.delete(oldest);
+                }
+        }
+
+        private async publishPlan(event: RoutingPlanEvent): Promise<void> {
+                if (!this.bus) return;
+                await this.bus.publish(OrchestrationEventTypes.RoutingPlan, event);
+        }
+
+        private async publishDecision(event: RoutingDecisionEvent): Promise<void> {
+                if (!this.bus) return;
+                await this.bus.publish(OrchestrationEventTypes.RoutingDecision, event);
+        }
+
+        private async publishFallback(event: RoutingFallbackEvent): Promise<void> {
+                if (!this.bus) return;
+                await this.bus.publish(OrchestrationEventTypes.RoutingFallback, event);
+        }
+}

--- a/packages/orchestration/src/service.ts
+++ b/packages/orchestration/src/service.ts
@@ -67,6 +67,9 @@ export function provideOrchestration(
                 },
                 shutdown: async () => {
                         await router.close();
+                        if (typeof bus.close === 'function') {
+                                await bus.close();
+                        }
                 },
         };
 }

--- a/packages/orchestration/src/service.ts
+++ b/packages/orchestration/src/service.ts
@@ -1,5 +1,9 @@
+import { resolve } from 'node:path';
 import type { Logger } from 'winston';
+
+import { createOrchestrationBus } from './events/orchestration-bus.js';
 import { createCerebrumGraph } from './langgraph/create-cerebrum-graph.js';
+import { PolicyRouter } from './routing/policy-router.js';
 import type { Agent, OrchestrationConfig, PlanningContext, Task } from './types.js';
 
 // Defer hooks init to runtime to avoid build order issues; dynamic import inside method
@@ -16,50 +20,55 @@ const DEFAULT_FACADE_CONFIG: OrchestrationConfig = {
 };
 
 export interface OrchestrationFacade {
-	engine: { kind: 'langgraph' };
-	config: OrchestrationConfig;
-	run: (
-		task: Task,
-		agents: Agent[],
-		context?: Partial<PlanningContext>,
-		neurons?: unknown[],
-	) => Promise<unknown>;
-	shutdown: () => Promise<void>;
+        engine: { kind: 'langgraph' };
+        config: OrchestrationConfig;
+        run: (
+                task: Task,
+                agents: Agent[],
+                context?: Partial<PlanningContext>,
+                neurons?: unknown[],
+        ) => Promise<unknown>;
+        router: PolicyRouter;
+        shutdown: () => Promise<void>;
 }
 
 export function provideOrchestration(
-	_config: Partial<OrchestrationConfig> = {},
-	_logger?: Logger,
+        _config: Partial<OrchestrationConfig> = {},
+        _logger?: Logger,
 ): OrchestrationFacade {
-	const engine = { kind: 'langgraph' as const };
-	const graph = createCerebrumGraph();
-	const config: OrchestrationConfig = {
-		...DEFAULT_FACADE_CONFIG,
-		..._config,
-		defaultStrategy: _config.defaultStrategy ?? DEFAULT_FACADE_CONFIG.defaultStrategy,
-	};
+        const engine = { kind: 'langgraph' as const };
+        const bus = createOrchestrationBus();
+        const policyPath = resolve(process.cwd(), '.cortex/policy/routing/routing-policy.yaml');
+        const router = new PolicyRouter(policyPath, { bus });
+        const graph = createCerebrumGraph({ router });
+        const config: OrchestrationConfig = {
+                ...DEFAULT_FACADE_CONFIG,
+                ..._config,
+                defaultStrategy: _config.defaultStrategy ?? DEFAULT_FACADE_CONFIG.defaultStrategy,
+        };
 
-	return {
-		engine,
-		config,
-		run: async (
-			task: Task,
-			_agents: Agent[],
-			_context: Partial<PlanningContext> = {},
-			_neurons: unknown[] = [],
-		) => {
+        return {
+                engine,
+                config,
+                router,
+                run: async (
+                        task: Task,
+                        _agents: Agent[],
+                        _context: Partial<PlanningContext> = {},
+                        _neurons: unknown[] = [],
+                ) => {
 			// Minimal mapping from Task -> graph input for now
 			const input = task.title || task.description || 'run';
 			const result = await graph.invoke({ input });
-			// As this facade provides a minimal runtime mapping to the LangGraph program,
-			// the invoke payload is intentionally simple to avoid brittle cross-package
-			// type requirements during incremental refactors.
-			return result;
-		},
-		shutdown: async () => {
-			// Noop for now (no persistent resources yet)
-		},
-	};
+                        // As this facade provides a minimal runtime mapping to the LangGraph program,
+                        // the invoke payload is intentionally simple to avoid brittle cross-package
+                        // type requirements during incremental refactors.
+                        return result;
+                },
+                shutdown: async () => {
+                        await router.close();
+                },
+        };
 }
 
 export class OrchestrationService {

--- a/packages/orchestration/src/types.ts
+++ b/packages/orchestration/src/types.ts
@@ -179,10 +179,48 @@ export interface DSPPlanningComplianceIssue {
 }
 
 export interface DSPPlanningCompliance {
-	standards: string[];
-	lastCheckedAt: Date | null;
-	riskScore: number;
-	outstandingViolations: DSPPlanningComplianceIssue[];
+        standards: string[];
+        lastCheckedAt: Date | null;
+        riskScore: number;
+        outstandingViolations: DSPPlanningComplianceIssue[];
+}
+
+export interface RoutingRequest {
+        requestId?: string;
+        interfaceId: string;
+        capabilities: string[];
+        tags?: string[];
+        source?: string;
+        command?: string;
+        env?: string;
+        operation?: string;
+        metadata?: Record<string, unknown>;
+}
+
+export interface RoutingCandidate {
+        agent: string;
+        score: number;
+        capabilities: string[];
+        reasons: string[];
+}
+
+export interface RoutingApproval {
+        required: boolean;
+        approvers: string[];
+        policies: string[];
+}
+
+export interface RoutingDecision {
+        requestId: string;
+        interfaceId: string;
+        policyVersion: string;
+        request: Required<RoutingRequest>;
+        selectedAgent: string;
+        candidates: RoutingCandidate[];
+        appliedRules: string[];
+        approval: RoutingApproval;
+        fallback?: { agent: string; reason: string } | null;
+        createdAt: string;
 }
 
 export interface DSPPlanningContext {

--- a/packages/orchestration/tests/routing/policy-router.failure.test.ts
+++ b/packages/orchestration/tests/routing/policy-router.failure.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PolicyRouter } from '../../src/routing/policy-router.js';
+
+describe('PolicyRouter failure handling', () => {
+        let tempDir: string;
+        let policyPath: string;
+
+        beforeEach(() => {
+                        tempDir = mkdtempSync(join(tmpdir(), 'policy-router-failure-'));
+                        policyPath = join(tempDir, 'routing-policy.yaml');
+                        writeFileSync(
+                                policyPath,
+                                [
+                                        'version: 0.4',
+                                        'interfaces:',
+                                        '  cli:',
+                                        '    app: apps/cortex-os',
+                                        '    priority_base: 10',
+                                        '    safety:',
+                                        '      allow_network: false',
+                                        '      allow_fs_write: tempdir',
+                                        'routing:',
+                                        '  strategy:',
+                                        '    plan_with: packages/orchestration/planners/policy-driven',
+                                        '    select_by:',
+                                        '      - capability_score',
+                                        '    fallbacks:',
+                                        '      - packages/agents/generalist',
+                                        '    guardrails: packages/security/policies/llm-guardrails.yaml',
+                                        '    evidence:',
+                                        '      require_provenance: true',
+                                        '      sink: packages/memories',
+                                        'capability_matrix:',
+                                        '  required:',
+                                        '    - id: review',
+                                        "      providers: ['packages/agents/generalist']",
+                                        '  incompatible: []',
+                                ].join('\n'),
+                                'utf8',
+                        );
+        });
+
+        afterEach(async () => {
+                await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it('throws when interface is missing in policy', async () => {
+                const router = new PolicyRouter(policyPath);
+                await expect(
+                        router.route({ interfaceId: 'webui', capabilities: ['code_edit'] }),
+                ).rejects.toThrow(/interface_missing/);
+                await router.close();
+        });
+});

--- a/packages/orchestration/tests/routing/policy-router.test.ts
+++ b/packages/orchestration/tests/routing/policy-router.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PolicyRouter } from '../../src/routing/policy-router.js';
+
+describe('PolicyRouter', () => {
+        let tempDir: string;
+        let policyPath: string;
+
+        beforeEach(() => {
+                        tempDir = mkdtempSync(join(tmpdir(), 'policy-router-'));
+                        policyPath = join(tempDir, 'routing-policy.yaml');
+                        writeFileSync(
+                                policyPath,
+                                [
+                                        'version: 0.4',
+                                        'interfaces:',
+                                        '  cli:',
+                                        '    app: apps/cortex-os',
+                                        '    priority_base: 80',
+                                        '    safety:',
+                                        '      allow_network: true',
+                                        '      allow_fs_write: workspace_only',
+                                        'routing:',
+                                        '  strategy:',
+                                        '    plan_with: packages/orchestration/planners/policy-driven',
+                                        '    select_by:',
+                                        '      - capability_score',
+                                        '    fallbacks:',
+                                        '      - packages/agents/generalist',
+                                        '    guardrails: packages/security/policies/llm-guardrails.yaml',
+                                        '    evidence:',
+                                        '      require_provenance: true',
+                                        '      sink: packages/memories',
+                                        'capability_matrix:',
+                                        '  required:',
+                                        '    - id: code_edit',
+                                        "      providers: ['packages/agents/dev']",
+                                        '  incompatible: []',
+                                ].join('\n'),
+                                'utf8',
+                        );
+        });
+
+        afterEach(async () => {
+                await rm(tempDir, { recursive: true, force: true });
+        });
+
+        it('selects a provider based on capability requirements', async () => {
+                const router = new PolicyRouter(policyPath);
+                const decision = await router.route({ interfaceId: 'cli', capabilities: ['code_edit'] });
+                expect(decision.selectedAgent).toBe('packages/agents/dev');
+                const explanation = router.explain(decision.requestId);
+                expect(explanation?.selectedAgent).toBe('packages/agents/dev');
+                await router.close();
+        });
+});

--- a/schemas/routing-policy.schema.json
+++ b/schemas/routing-policy.schema.json
@@ -1,0 +1,419 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cortex.brainwav.ai/schemas/routing-policy.schema.json",
+  "title": "RoutingPolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "owner": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "last_review": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "owner",
+        "description"
+      ]
+    },
+    "interfaces": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "app": {
+              "type": "string"
+            },
+            "pkg": {
+              "type": "string"
+            },
+            "priority_base": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "safety": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow_network": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "const": "ask"
+                    }
+                  ]
+                },
+                "allow_fs_write": {
+                  "enum": [
+                    "workspace_only",
+                    "tempdir",
+                    "forbid"
+                  ]
+                },
+                "sandbox": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "allow_network",
+                "allow_fs_write"
+              ]
+            }
+          },
+          "required": [
+            "priority_base",
+            "safety"
+          ]
+        }
+      }
+    },
+    "priority_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "if": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "interface": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "env": {
+                "type": "string"
+              },
+              "operation": {
+                "type": "string"
+              },
+              "operation_any": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "tags_any": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "command_prefix_any": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "path_not_in": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "then": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "boost": {
+                "type": "integer"
+              },
+              "prefer_capabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "require_approval": {
+                "type": "boolean"
+              },
+              "safety_override": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "allow_network": {
+                    "oneOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "const": "ask"
+                      }
+                    ]
+                  },
+                  "allow_fs_write": {
+                    "enum": [
+                      "workspace_only",
+                      "tempdir",
+                      "forbid"
+                    ]
+                  },
+                  "sandbox": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "then"
+        ]
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "plan_with": {
+              "type": "string"
+            },
+            "select_by": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            "fallbacks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "guardrails": {
+              "type": "string"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "require_provenance": {
+                  "type": "boolean"
+                },
+                "sink": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "require_provenance",
+                "sink"
+              ]
+            }
+          },
+          "required": [
+            "plan_with",
+            "select_by",
+            "guardrails",
+            "evidence"
+          ]
+        }
+      },
+      "required": [
+        "strategy"
+      ]
+    },
+    "capability_matrix": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "providers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "id",
+              "providers"
+            ]
+          },
+          "minItems": 1
+        },
+        "incompatible": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "disallow_providers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "id",
+              "disallow_providers"
+            ]
+          }
+        }
+      },
+      "required": [
+        "required"
+      ]
+    },
+    "approvals": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "if": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "interface": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "env": {
+                    "type": "string"
+                  },
+                  "operation": {
+                    "type": "string"
+                  },
+                  "operation_any": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tags_any": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "command_prefix_any": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "path_not_in": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "require_approval": {
+                    "type": "boolean"
+                  },
+                  "approvers": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "require_approval"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "then"
+            ]
+          }
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "otel_spans": {
+          "type": "boolean"
+        },
+        "a2a_events_topic": {
+          "type": "string"
+        },
+        "redact": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "otel_spans",
+        "a2a_events_topic"
+      ]
+    }
+  },
+  "required": [
+    "version",
+    "interfaces",
+    "routing",
+    "capability_matrix"
+  ]
+}

--- a/scripts/policies/generate-routing-policy-schema.cjs
+++ b/scripts/policies/generate-routing-policy-schema.cjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+const { writeFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const outputPath = resolve(__dirname, '../../schemas/routing-policy.schema.json');
+
+const safetySchema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                allow_network: {
+                        oneOf: [
+                                { type: 'boolean' },
+                                { const: 'ask' },
+                        ],
+                },
+                allow_fs_write: {
+                        enum: ['workspace_only', 'tempdir', 'forbid'],
+                },
+                sandbox: { type: 'string' },
+        },
+        required: ['allow_network', 'allow_fs_write'],
+};
+
+const safetyOverrideSchema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                allow_network: safetySchema.properties.allow_network,
+                allow_fs_write: safetySchema.properties.allow_fs_write,
+                sandbox: { type: 'string' },
+        },
+};
+
+const conditionSchema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                interface: { type: 'string' },
+                source: { type: 'string' },
+                env: { type: 'string' },
+                operation: { type: 'string' },
+                operation_any: { type: 'array', items: { type: 'string' } },
+                tags_any: { type: 'array', items: { type: 'string' } },
+                command_prefix_any: { type: 'array', items: { type: 'string' } },
+                path_not_in: { type: 'array', items: { type: 'string' } },
+        },
+};
+
+const priorityRuleSchema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                id: { type: 'string' },
+                if: conditionSchema,
+                then: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                                boost: { type: 'integer' },
+                                prefer_capabilities: { type: 'array', items: { type: 'string' } },
+                                require_approval: { type: 'boolean' },
+                                safety_override: safetyOverrideSchema,
+                        },
+                },
+        },
+        required: ['id', 'then'],
+};
+
+const capabilityEntrySchema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                id: { type: 'string' },
+                providers: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        },
+        required: ['id', 'providers'],
+};
+
+const incompatibleCapabilitySchema = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                id: { type: 'string' },
+                disallow_providers: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        },
+        required: ['id', 'disallow_providers'],
+};
+
+const routingPolicySchema = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'https://cortex.brainwav.ai/schemas/routing-policy.schema.json',
+        title: 'RoutingPolicy',
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+                version: { type: 'string', minLength: 1 },
+                metadata: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                                owner: { type: 'string' },
+                                description: { type: 'string' },
+                                last_review: { type: 'string' },
+                        },
+                        required: ['owner', 'description'],
+                },
+                interfaces: {
+                        type: 'object',
+                        minProperties: 1,
+                        additionalProperties: false,
+                        patternProperties: {
+                                '^.*$': {
+                                        type: 'object',
+                                        additionalProperties: false,
+                                        properties: {
+                                                app: { type: 'string' },
+                                                pkg: { type: 'string' },
+                                                priority_base: { type: 'integer', minimum: 0 },
+                                                safety: safetySchema,
+                                        },
+                                        required: ['priority_base', 'safety'],
+                                },
+                        },
+                },
+                priority_rules: {
+                        type: 'array',
+                        items: priorityRuleSchema,
+                },
+                routing: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                                strategy: {
+                                        type: 'object',
+                                        additionalProperties: false,
+                                        properties: {
+                                                plan_with: { type: 'string' },
+                                                select_by: { type: 'array', items: { type: 'string' }, minItems: 1 },
+                                                fallbacks: { type: 'array', items: { type: 'string' } },
+                                                guardrails: { type: 'string' },
+                                                evidence: {
+                                                        type: 'object',
+                                                        additionalProperties: false,
+                                                        properties: {
+                                                                require_provenance: { type: 'boolean' },
+                                                                sink: { type: 'string' },
+                                                        },
+                                                        required: ['require_provenance', 'sink'],
+                                                },
+                                        },
+                                        required: ['plan_with', 'select_by', 'guardrails', 'evidence'],
+                                },
+                        },
+                        required: ['strategy'],
+                },
+                capability_matrix: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                                required: {
+                                        type: 'array',
+                                        items: capabilityEntrySchema,
+                                        minItems: 1,
+                                },
+                                incompatible: {
+                                        type: 'array',
+                                        items: incompatibleCapabilitySchema,
+                                },
+                        },
+                        required: ['required'],
+                },
+                approvals: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                                policies: {
+                                        type: 'array',
+                                        items: {
+                                                type: 'object',
+                                                additionalProperties: false,
+                                                properties: {
+                                                        id: { type: 'string' },
+                                                        if: conditionSchema,
+                                                        then: {
+                                                                type: 'object',
+                                                                additionalProperties: false,
+                                                                properties: {
+                                                                        require_approval: { type: 'boolean' },
+                                                                        approvers: { type: 'array', items: { type: 'string' } },
+                                                                },
+                                                                required: ['require_approval'],
+                                                        },
+                                                },
+                                                required: ['id', 'then'],
+                                        },
+                                },
+                        },
+                },
+                telemetry: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                                otel_spans: { type: 'boolean' },
+                                a2a_events_topic: { type: 'string' },
+                                redact: {
+                                        type: 'object',
+                                        additionalProperties: false,
+                                        properties: {
+                                                fields: { type: 'array', items: { type: 'string' } },
+                                        },
+                                },
+                        },
+                        required: ['otel_spans', 'a2a_events_topic'],
+                },
+        },
+        required: ['version', 'interfaces', 'routing', 'capability_matrix'],
+};
+
+writeFileSync(outputPath, `${JSON.stringify(routingPolicySchema, null, 2)}\n`, { encoding: 'utf-8' });
+console.log('brAInwav policy: routing-policy schema updated');


### PR DESCRIPTION
## Summary
- add the unified routing policy contracts, schema generator, and router implementation for orchestration
- expose routing plan/decision events over A2A/MCP and export the new PolicyRouter surface
- wire the runtime HTTP server to provide /v1/routing dry-run and explain endpoints backed by the orchestration router

## Testing
- pnpm --filter @cortex-os/orchestration test *(fails: vitest binary is not available in the execution environment)*
- pnpm --filter @apps/cortex-os test *(fails: vitest binary is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16a95f738832c80349b8a81f4f96b